### PR TITLE
Add generative p5.js screensaver example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# p5.js 3D Screensaver
+
+This project generates an evolving 3D artwork using p5.js with a custom GLSL
+shader. Each time the screensaver launches it randomises its layout so the
+pattern is always unique.
+
+## Running
+
+1. Install [Node.js](https://nodejs.org/) and npm.
+2. Install dependencies (requires network access):
+   ```
+   npm install
+   ```
+3. Start the screensaver in a window:
+   ```
+   npm start
+   ```
+
+The sketch runs full screen when opened with Electron.
+
+## Packaging for Windows
+
+To turn this project into a Windows screensaver:
+
+1. Install `electron-packager` globally:
+   ```
+   npm install --global electron-packager
+   ```
+2. Package the application:
+   ```
+   electron-packager . p5Screensaver --platform=win32 --arch=x64 --overwrite
+   ```
+3. Inside the generated `p5Screensaver-win32-x64` folder, rename the produced
+   `.exe` file to `.scr` and move it to your Windows system directory.
+
+When launched, the screensaver displays animated boxes coloured by a shader.
+Their motion is affected by neighbouring boxes, producing a unique scene each
+run.

--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,16 @@
+const { app, BrowserWindow } = require('electron');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    fullscreen: true,
+    frame: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  });
+  win.loadFile('src/index.html');
+  win.setMenuBarVisibility(false);
+}
+
+app.whenReady().then(createWindow);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "p5js-screensaver",
+  "version": "1.0.0",
+  "description": "Generative p5.js screensaver with WebGL shader",
+  "main": "electron.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^29.0.0"
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Generative Screensaver</title>
+    <style>
+      html, body, canvas { margin: 0; padding: 0; overflow: hidden; }
+    </style>
+  </head>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,64 @@
+let modules = [];
+let shaderProgram;
+
+function preload() {
+  shaderProgram = loadShader('shaders/vert.glsl', 'shaders/frag.glsl');
+}
+
+function setup() {
+  createCanvas(windowWidth, windowHeight, WEBGL);
+  noStroke();
+  randomSeed(millis());
+  const num = 20 + int(random(10));
+  for (let i = 0; i < num; i++) {
+    modules.push(new Module());
+  }
+}
+
+function draw() {
+  background(0);
+  rotateY(frameCount * 0.001);
+  for (let m of modules) {
+    m.update(modules);
+    m.display();
+  }
+}
+
+class Module {
+  constructor() {
+    this.pos = createVector(random(-200, 200), random(-200, 200), random(-200, 200));
+    this.vel = p5.Vector.random3D().mult(random(0.5));
+    this.size = random(20, 80);
+  }
+  update(others) {
+    for (let o of others) {
+      if (o !== this) {
+        const d = p5.Vector.dist(this.pos, o.pos);
+        if (d < 80) {
+          const repulse = p5.Vector.sub(this.pos, o.pos).normalize().mult(0.5);
+          this.vel.add(repulse);
+        }
+      }
+    }
+    this.pos.add(this.vel);
+    if (this.pos.mag() > 300) {
+      this.pos.mult(-0.9);
+    }
+    this.vel.mult(0.98);
+  }
+  display() {
+    push();
+    translate(this.pos.x, this.pos.y, this.pos.z);
+    shader(shaderProgram);
+    shaderProgram.setUniform('u_time', millis() / 1000.0);
+    shaderProgram.setUniform('u_resolution', [width, height]);
+    shaderProgram.setUniform('u_pos', [this.pos.x, this.pos.y, this.pos.z]);
+    box(this.size);
+    resetShader();
+    pop();
+  }
+}
+
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+}

--- a/src/shaders/frag.glsl
+++ b/src/shaders/frag.glsl
@@ -1,0 +1,32 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform float u_time;
+uniform vec2 u_resolution;
+uniform vec3 u_pos;
+
+varying vec3 vPosition;
+
+// Simple 2D noise
+float random(vec2 st) {
+  return fract(sin(dot(st.xy, vec2(12.9898,78.233))) * 43758.5453123);
+}
+
+float noise(vec2 st) {
+  vec2 i = floor(st);
+  vec2 f = fract(st);
+  float a = random(i);
+  float b = random(i + vec2(1.0, 0.0));
+  float c = random(i + vec2(0.0, 1.0));
+  float d = random(i + vec2(1.0, 1.0));
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+void main() {
+  vec2 st = gl_FragCoord.xy / u_resolution.xy;
+  float n = noise(st * 3.0 + u_time + u_pos.xy * 0.01);
+  vec3 color = mix(vec3(0.2,0.0,0.5), vec3(0.9,0.9,0.2), n);
+  gl_FragColor = vec4(color, 1.0);
+}

--- a/src/shaders/vert.glsl
+++ b/src/shaders/vert.glsl
@@ -1,0 +1,15 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+attribute vec3 aPosition;
+
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+
+varying vec3 vPosition;
+
+void main() {
+  vPosition = aPosition;
+  gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aPosition, 1.0);
+}


### PR DESCRIPTION
## Summary
- add electron entry point
- add p5.js sketch using WebGL shader
- provide GLSL vertex and fragment shaders
- include instructions on how to run and package as a Windows screensaver

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`